### PR TITLE
Add retry for REST requests, Reuse login session when uploading files…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# XNAT File Transfer
+
+## `project-importer.py`
+
+### How to use?
+
+- Open `~/<whatever>/data/config.ini` and enter your username and password.
+- Put the `*.dcm` files under: `~/<whatever>/data/projects/<ProjName>/<any>/<SeriesID>/*.dcm`
+- Run `upload.cmd` and type / paste the ProjectName (`<ProjName>`).
+- Press `Enter` to start batch upload!
+
+The zip file downloaded from Phillips IntelliSpace Discovery can be used directly after unzipping, without changing the folder name / hierarchy.
+
+### Example
+
+Open `data\config.ini` and enter your username and password.
+
+Our folder hierarchy:
+
+```
+D:\xnat-file-importer-0.41\data\projects\v1_test_\
+|
++---S.0
+|   +---S00
+|   |       Image0001.dcm
+|   |       ...
+|   |       Image2007.dcm
+|   |
+|   +---S6010
+|   |       Image0001.dcm
+|   |
+|   \---S9030
+|           Image0001.dcm
+|           ...
+|           Image0018.dcm
+|
+\---S.1
+    +---S00
+    |       Image0001.dcm
+    |
+    \---S10
+            Image0001.dcm
+```
+
+Run `upload.cmd` and paste: `v1_test_`, press `Enter` and wait for finish.

--- a/project-importer.py
+++ b/project-importer.py
@@ -1,4 +1,3 @@
-from lxml import etree
 import csv
 import traceback
 import subprocess
@@ -9,29 +8,40 @@ import os
 import pdb
 import sys
 import logging
+
+import time
+import functools
 """
 Assume user put the data in this directory structure
-/<whatever>/projects/<project_ID>/<subject_ID>/<session_ID>/<session_data_type>/<scan_id>/<xant_data_type>/<scan_data_type>.
+/<whatever>/data/projects/<project_ID>/<whatever>/<scan_ID>/*.dcm
 
 session_data_type:
     RAW, (support DICOM and others)
     RECON -> reconstructions (support NFTI)
- 
+
 """
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
-VER=0.4
+VER=0.41
+try:
+    from lxml import etree
+except:
+    print('please type "pip install lxml" for installing lxml package')
 
 try:
     import requests
 except:
     print('please type "pip install requests" for installing request package')
 
+try:
+    import pydicom
+except:
+    print('please type "pip install pydicom" for installing pydicom package')
+
 requests.packages.urllib3.disable_warnings()
 
 # r = requests.get('https://dmxnat.nchc.org.tw/data/projects', auth=('admin', 'admin@steps'), verify=False)
-
 
 class XnatImporter:
     XNAT_CONF_NAME = 'config.ini'
@@ -79,7 +89,7 @@ class XnatImporter:
             return (username, password)
         except configparser.NoSectionError:
             logging.error(
-                'please check the config file is exsit and format is right!')
+                'please check the config file exist and format is right!')
         except:
             raise
 
@@ -107,6 +117,24 @@ class XnatImporter:
             logging.error(r.text)
             print(r.text)
             raise EOFError
+
+    def xnatapi_upload(self, api, file_data, base_filename):
+        cookies = dict(JSESSIONID=self.session_id)
+        api_url = api
+
+        r = requests.put(
+            api_url,
+            data=file_data,
+            headers={'content-type': 'text/plain'},
+            params={'file': base_filename},
+            cookies=cookies,
+            verify=False
+        )
+
+        if r.status_code == 401:
+            if self.session_request() == True:
+                return self.xnatapi_upload(api, file_data, base_filename)
+        return r
 
     def xnatapi(self, api, action='get', raw=0):
         cookies = dict(JSESSIONID=self.session_id)
@@ -142,6 +170,40 @@ class XnatImporter:
     def build_full_file_path(self, dir_info):
         return [os.path.join(dir_info[0], file_name) for file_name in dir_info[2]]
 
+    def build_restapi_parameter_through_dicom(self, dir_info):
+        dir_structure = dir_info[0].split(os.sep)
+        start_pos = dir_structure.index('projects')
+        file_full_names = self.build_full_file_path(dir_info)
+
+        logging.info(dir_info)
+
+        enabled_data_type = ['cr', 'ct', 'mr', 'hd']
+
+        # DICOM images in the same series should be in same date (session), project, subject, scan type
+        ds = pydicom.dcmread(file_full_names[0])
+
+        params = {
+            'project_id': dir_structure[start_pos + 1],
+            'subject_id': str(ds.PatientName),
+            'session_id': ds.StudyDate[0:4] + '_' + ds.StudyDate[4:6] + '_' + ds.StudyDate[6:8],
+            'session_data_type': 'RAW',
+            'scan_id': dir_structure[start_pos + 3],
+            'xnat_data_type': ds.Modality.lower() + 'ScanData',
+            'data_type': ds.Modality.lower(),
+            'scan_data_type': 'DICOM',
+            'file_names': file_full_names
+        }
+
+        params['session_id'] = params['subject_id'] + '_' + params['session_id']
+        # TODO: Not sure if the following works or not
+        # XFollow the Modality in DICOM tags
+        if params['data_type'] not in enabled_data_type:
+            params['data_type'] = 'otherDicom'
+            params['xnat_data_type'] = 'otherDicomScanData'
+            params['scan_data_type'] = 'otherDicom'
+
+        return params
+
     def build_restapi_parameter(self, dir_info):
         dir_structure = dir_info[0].split(os.sep)
         start_pos = dir_structure.index('projects')
@@ -170,6 +232,22 @@ class XnatImporter:
 
         return params
 
+    def retry(self, name, function, max_retries=1000):
+        """Retries a certain function for at most max_retry times
+        Assumes the function returns true on success.
+        """
+        retry_count = 0
+        while retry_count < max_retries:
+            # Execute
+            ret = function()
+            if ret:
+                return
+            # Sleep and try again
+            retry_count += 1
+            print("Retry({0}) {1}...".format(retry_count, name))
+            time.sleep(retry_count / 10)
+        print("Retry count exceeds max retries({0})!!".format(max_retries))
+
     def xnat_create_project(self, params, auth_info):
         api_url = '/'.join([self.XNAT_BASE_URL, 'data',
                             'projects', params['project_id']])
@@ -177,10 +255,12 @@ class XnatImporter:
         r = self.xnatapi(api_url, 'put', 1)
         if r.status_code < 400:
             logging.info('create project successfully!')
+            return True
         else:
             logging.error('please check the status of xnat_create_project')
             logging.error(r.status_code)
             logging.error(r.text)
+        return False
 
     def xnat_create_subject(self, params, auth_info):
         api_url = '/'.join([self.XNAT_BASE_URL, 'data', 'projects',
@@ -188,17 +268,19 @@ class XnatImporter:
         r = self.xnatapi(api_url, 'get',  1)
         if r.status_code == 200:
             logging.info('{0} exist!'.format(api_url))
-            return
+            return True
 
         #r = requests.put(api_url, auth=(
         #    auth_info[0], auth_info[1]), verify=False)
         r = self.xnatapi(api_url, 'put',  1)
         if r.status_code < 400:
             logging.info('create subject successfully!')
+            return True
         else:
             logging.error('please check the status of xnat_create_subject')
             logging.error(r.status_code)
             logging.error(r.text)
+        return False
 
     def xnat_create_session(self, params, auth_info):
         dateobj = datetime.date.today()
@@ -211,23 +293,21 @@ class XnatImporter:
         r = self.xnatapi(api_url, 'get', 1)
         if r.status_code == 200:
             logging.info('{0} exist!'.format(api_url))
-            return
 
         api_url = api_url + query_params
         r = self.xnatapi(api_url, 'put', 1)
         if r.status_code < 400:
             logging.info('create session successfully!')
+            return True
         else:
             logging.error('please check the status of xnat_create_session')
             logging.error(r.status_code)
             logging.error(r.text)
+        return False
 
     def xnat_create_scan(self, params, auth_info):
         #query_params = '?xsiType=xnat:' + params['xnat_data_type'] + '&xnat:' + params['xnat_data_type'] + '/type=' + params['scan_data_type']
-        # http://140.110.28.227/data/archive/projects/nchc_lca_dev_2019102514/\
-        #        subjects/NCHC02_S00268/experiments/NCHC02_E00228/scans/scan001?\
-        #format=json&xnat:ctScanData/type=unknow&xnat:ctScanData/quality=usable
-        query_params = '?xsiType=xnat:' + params['xnat_data_type'] + '&xnat:' + params['xnat_data_type'] + '/type=Unknow&xnat:' + params['xnat_data_type'] + '/quality=usable'
+        query_params = '?xsiType=xnat:' + params['xnat_data_type']
         api_url = '/'.join([
             self.XNAT_BASE_URL, 'data',
             'projects', params['project_id'],
@@ -239,7 +319,7 @@ class XnatImporter:
         if r.status_code == 200:
             logging.info('{0} exist!'.format(api_url))
             self.scanExist = 1
-            return
+            return True
 
         api_url = api_url + query_params
         #r = requests.put(api_url, auth=(
@@ -247,8 +327,10 @@ class XnatImporter:
         r = self.xnatapi(api_url, 'put', 1)
         if r.status_code < 400:
             logging.info('create scan successfully!')
+            return True
         else:
             logging.info('please check the status of xnat_create_scan')
+        return False
 
     def xnat_create_resource_for_scan(self, params, auth_info):
         if params['session_data_type'] == 'DICOM':
@@ -282,7 +364,7 @@ class XnatImporter:
         elif params['session_data_type'] == 'RAW':
             if self.scanExist == 1:
                 logging.info('scan exist, skip resource!')
-                return
+                return True
 
             api_url = '/'.join([
                 self.XNAT_BASE_URL, 'data',
@@ -310,11 +392,14 @@ class XnatImporter:
 
         if r.status_code < 400:
             logging.info('create resource successfully!')
+            return True
         elif r.status_code == 409:
             logging.info('The resource already exist: ' + api_url)
+            return True
         else:
             logging.info('please check the status of creation')
             logging.info(r.status_code)
+        return False
 
     def check_with_lxml(self, file_name):
         xsd = etree.parse(self.AIM_SCHEMA_XSD)
@@ -346,111 +431,115 @@ class XnatImporter:
         else:
             return False
 
+    def xnat_upload_raw_file(self, file_name, params, auth_info):
+        base_filename = os.path.basename(file_name)
+
+        logging.info('File Extension: ' + base_filename[-3:])
+        abspardir = os.path.abspath(os.path.join(file_name, os.pardir))
+        pardir = os.path.basename(abspardir)
+
+        # if base_filename[-3:] == 'dcm':
+        if pardir == 'DICOM':
+            api_url = '/'.join([
+                self.XNAT_BASE_URL, 'data',
+                'projects', params['project_id'],
+                'subjects', params['subject_id'],
+                'experiments', params['session_id'],
+                'scans', params['scan_id'],
+                'resources/DICOM/files/' + base_filename
+            ])
+        elif pardir == 'METADATA':
+            api_url = '/'.join([
+                self.XNAT_BASE_URL, 'data',
+                'projects', params['project_id'],
+                'subjects', params['subject_id'],
+                'experiments', params['session_id'],
+                'scans', params['scan_id'],
+                'resources/METADATA/files/' + base_filename
+            ])
+        else:
+            api_url = '/'.join([
+                self.XNAT_BASE_URL, 'data',
+                'projects', params['project_id'],
+                'subjects', params['subject_id'],
+                'experiments', params['session_id'],
+                'scans', params['scan_id'],
+                'resources/OTHERS/files/' + base_filename
+            ])
+
+        r = self.xnatapi(api_url, 'get', 1)
+        if r.status_code == 200:
+            logging.info('{0} exist!'.format(api_url))
+            self.results['exist'].append(file_name)
+            # Continue makes more sense?
+            # return
+            return True
+
+        if base_filename[-7:] == 'aim.xml' and pardir == 'METADATA':
+            # verify xml
+            if not self.verify_xml(file_name):
+                self.results['fail'].append(
+                    [file_name, 'xml validate failed'])
+                # Failed but maybe shouldn't retry?
+                return False
+
+        with open(file_name, 'rb') as fh:
+            file_data = fh.read()
+            r = self.xnatapi_upload(api_url, file_data, base_filename)
+
+            if r.status_code < 400:
+                self.results['success'].append(file_name)
+
+                logging.info('upload ' + base_filename +
+                                ' successuflly!')
+                logging.info(r.text)
+                return True
+            else:
+                self.results['fail'].append(file_name)
+
+                logging.error('upload failed: ' + file_name)
+                logging.error(r.text)
+        return False
+
+    def xnat_upload_recon_file(self, file_name, params, auth_info):
+        base_filename = os.path.basename(file_name)
+        api_url = '/'.join([
+            self.XNAT_BASE_URL, 'data',
+            'projects', params['project_id'],
+            'subjects', params['subject_id'],
+            'experiments', params['session_id'],
+            'scans', params['scan_id'],
+            'reconstructions/' +
+            params['scan_id'] +
+            '/resources/NIFTI/files/' + base_filename
+        ])
+
+        with open(file_name, 'rb') as fh:
+            file_data = fh.read()
+            r = requests.put(
+                api_url,
+                data=file_data,
+                headers={'content-type': 'text/plain'},
+                params={'file': base_filename},
+                auth=(auth_info[0], auth_info[1]),
+                verify=False)
+
+            if r.status_code < 400:
+                # logging.info('upload ' + base_filename + ' successuflly!')
+                # logging.info(r.text)
+                return True
+            else:
+                logging.error('upload failed' + file_name)
+                logging.error(r.text)
+        return False
+
     def xnat_upload_files(self, params, auth_info):
         if params['session_data_type'] == 'RAW':
             for file_name in params['file_names']:
-                base_filename = os.path.basename(file_name)
-
-                logging.info('File Extension: ' + base_filename[-3:])
-                abspardir = os.path.abspath(os.path.join(file_name, os.pardir))
-                pardir = os.path.basename(abspardir)
-
-                # if base_filename[-3:] == 'dcm':
-                if pardir == 'DICOM':
-                    api_url = '/'.join([
-                        self.XNAT_BASE_URL, 'data',
-                        'projects', params['project_id'],
-                        'subjects', params['subject_id'],
-                        'experiments', params['session_id'],
-                        'scans', params['scan_id'],
-                        'resources/DICOM/files/' + base_filename
-                    ])
-                elif pardir == 'METADATA':
-                    api_url = '/'.join([
-                        self.XNAT_BASE_URL, 'data',
-                        'projects', params['project_id'],
-                        'subjects', params['subject_id'],
-                        'experiments', params['session_id'],
-                        'scans', params['scan_id'],
-                        'resources/METADATA/files/' + base_filename
-                    ])
-                else:
-                    api_url = '/'.join([
-                        self.XNAT_BASE_URL, 'data',
-                        'projects', params['project_id'],
-                        'subjects', params['subject_id'],
-                        'experiments', params['session_id'],
-                        'scans', params['scan_id'],
-                        'resources/OTHERS/files/' + base_filename
-                    ])
-
-                r = self.xnatapi(api_url, 'get', 1)
-                if r.status_code == 200:
-                    logging.info('{0} exist!'.format(api_url))
-                    self.results['exist'].append(file_name)
-                    return
-
-                if base_filename[-7:] == 'aim.xml' and pardir == 'METADATA':
-                    # verify xml
-                    if not self.verify_xml(file_name):
-                        self.results['fail'].append(
-                            [file_name, 'xml validate failed'])
-                        continue
-
-                with open(file_name, 'rb') as fh:
-                    file_data = fh.read()
-                    r = requests.put(
-                        api_url,
-                        data=file_data,
-                        headers={'content-type': 'text/plain'},
-                        params={'file': base_filename},
-                        auth=(auth_info[0], auth_info[1]),
-                        verify=False
-                    )
-
-                    if r.status_code < 400:
-                        self.results['success'].append(file_name)
-
-                        logging.info('upload ' + base_filename +
-                                     ' successuflly!')
-                        logging.info(r.text)
-                    else:
-                        self.results['fail'].append(file_name)
-
-                        logging.error('upload failed: ' + file_name)
-                        logging.error(r.text)
-
+                self.retry('upload_files:raw', functools.partial(self.xnat_upload_raw_file, file_name, params, auth_info))
         elif params['session_data_type'] == 'RECON':
             for file_name in params['file_names']:
-                base_filename = os.path.basename(file_name)
-                api_url = '/'.join([
-                    self.XNAT_BASE_URL, 'data',
-                    'projects', params['project_id'],
-                    'subjects', params['subject_id'],
-                    'experiments', params['session_id'],
-                    'scans', params['scan_id'],
-                    'reconstructions/' +
-                    params['scan_id'] +
-                    '/resources/NIFTI/files/' + base_filename
-                ])
-
-                with open(file_name, 'rb') as fh:
-                    file_data = fh.read()
-                    r = requests.put(
-                        api_url,
-                        data=file_data,
-                        headers={'content-type': 'text/plain'},
-                        params={'file': base_filename},
-                        auth=(auth_info[0], auth_info[1]),
-                        verify=False)
-
-                    if r.status_code < 400:
-                        # logging.info('upload ' + base_filename + ' successuflly!')
-                        # logging.info(r.text)
-                        pass
-                    else:
-                        logging.error('upload failed' + file_name)
-                        logging.error(r.text)
+                self.retry('upload_files:recon', functools.partial(self.xnat_upload_recon_file, file_name, params, auth_info))
 
     def do_api_request(self, auth_info, data_dir):
 
@@ -461,15 +550,16 @@ class XnatImporter:
             dir_info[2] = list(filter(lambda x: x != '.DS_Store', dir_info[2]))
 
             if index > 1 and len(dir_info[2]) > 0:
-                params = self.build_restapi_parameter(dir_info)
+                # This is only entered on *.dcm, *.xml, ... files (When file count > 0)
+                params = self.build_restapi_parameter_through_dicom(dir_info)
                 try:
                     self.scanExist = 0
-                    self.xnat_create_project(params, auth_info)
-                    self.xnat_create_subject(params, auth_info)
-                    self.xnat_create_session(params, auth_info)
-                    self.xnat_create_scan(params, auth_info)
-                    self.xnat_create_resource_for_scan(params, auth_info)
-                    self.xnat_upload_files(params, auth_info)
+                    self.retry('create_project', functools.partial(self.xnat_create_project, params, auth_info))
+                    self.retry('create_subject', functools.partial(self.xnat_create_subject, params, auth_info))
+                    self.retry('create_session', functools.partial(self.xnat_create_session, params, auth_info))
+                    self.retry('create_scan', functools.partial(self.xnat_create_scan, params, auth_info))
+                    self.retry('create_resource_for_scan', functools.partial(self.xnat_create_resource_for_scan, params, auth_info))
+                    self.xnat_upload_files(params, auth_info) # Already retry by itself.
                 except Exception:
                     traceback.print_exc()
 
@@ -484,6 +574,27 @@ class XnatImporter:
             csv_writer = csv.writer(csvfh, delimiter=',')
             for row in self.results['fail']:
                 csv_writer.writerow(row)
+
+    # def get_failed(self):
+    #     """Get last failed results
+    #     Returns an list array of self.results['fail']
+    #     """
+    #     failed = []
+    #     for row in self.results['fail']:
+    #         # The input entries might be one of the following:
+    #         # 1. file_name
+    #         #    row == '<file_name>'
+    #         # 2. [file_name, 'xml validate failed'])
+    #         #    row == '[<file_name>, 'xml validate failed']
+    #         file_name = row
+    #         action_type = 'file upload'
+    #         if isinstance(row, list):
+    #             # row == '[<file_name>, 'xml validate failed']
+    #             file_name = row[0]
+    #             action_type = 'xml validate'
+    #         failed.push([file_name, action_type])
+    #     return failed
+
 
 
 if __name__ == '__main__':

--- a/upload.cmd
+++ b/upload.cmd
@@ -1,0 +1,7 @@
+@echo off
+echo [XNAT batch file importer] (for vghtpe)
+echo The *.dcm files should be put at: ~/^<whatever^>/data/projects/^<ProjName^>/^<whatever^>/^<SeriesID^>/*.dcm
+echo e.g. v1_BrainMetastases_full/303010/S10/*.dcm
+set /p id="Enter Project Name (e.g. v1_BrainMetastases_full): "
+python project-importer.py %id%
+pause


### PR DESCRIPTION
Change Log (Modifications made)

`upload.cmd`
- Add `upload.cmd` for ease of use on Windows.

`project-importer.py`
- Add retry for REST requests
  Retry are enabled for:
  - `xnat_create_project`
  - `xnat_create_subject`
  - `xnat_create_session`
  - `xnat_create_scan`
  - `xnat_create_resource_for_scan`
  - `xnat_upload_files`
- Reuse login session when uploading files
  The original version retrieves a new session for each file, resulting many redundant login sessions. (This can ease the extra workload of the XNAT server)
- Simplify folder hierarchy (use DICOM tags instead)
  - File path
    New:
    `/<whatever>/projects/<project_ID>/<whatever>/<scan_ID>/*.dcm`
    Original:
    `/<whatever>/projects/<project_ID>/<subject_ID>/<session_ID>/<session_data_type>/<scan_id>/<xant_data_type>/<scan_data_type>.`
  - Parameters reading
    New:
    ```py
    ds = pydicom.dcmread(file_full_names[0])

    params = {
        'project_id': dir_structure[start_pos + 1],
        'subject_id': str(ds.PatientName),
        'session_id': ds.StudyDate[0:4] + '_' + ds.StudyDate[4:6] + '_' + ds.StudyDate[6:8],
        'session_data_type': 'RAW',
        'scan_id': dir_structure[start_pos + 3],
        'xnat_data_type': ds.Modality.lower() + 'ScanData',
        'data_type': ds.Modality.lower(),
        'scan_data_type': 'DICOM',
        'file_names': file_full_names
    }
    ```
    Original:
    ```py
    params = {
        'project_id': dir_structure[start_pos + 1],
        'subject_id': dir_structure[start_pos + 2],
        'session_id': dir_structure[start_pos + 3],
        'session_data_type': dir_structure[start_pos + 4],
        'scan_id': dir_structure[start_pos + 5],
        'xnat_data_type': dir_structure[start_pos + 6] + 'ScanData',
        'data_type': dir_structure[start_pos + 6],
        'scan_data_type': dir_structure[start_pos + 7],
        'file_names': file_full_names
    }
    ```
- Drawbacks: this version can only upload DICOM files. (Doesn't support xml, ... files)
  I think this won't be too hard to fix, but I didn't have the xml files to test at that time...